### PR TITLE
system icons

### DIFF
--- a/Project_1_QT/mainwindow.cpp
+++ b/Project_1_QT/mainwindow.cpp
@@ -53,6 +53,13 @@ MainWindow::MainWindow(QWidget *parent)
    connect(uiMainWindow->actionClose_App,SIGNAL(triggered()),this,SLOT(onAppClose()));
 
    connect(this,SIGNAL(appClose()),sceneView,SLOT(onAppClose()));
+
+   //set system theme to icons
+   uiMainWindow->actionClose_App->setIcon(QIcon::fromTheme("dialog-close"));
+   uiMainWindow->actionClose_Scene->setIcon(QIcon::fromTheme("document-close"));
+   uiMainWindow->actionSave_Scene->setIcon(QIcon::fromTheme("document-save"));
+   uiMainWindow->actionC->setIcon(QIcon::fromTheme("document-open"));
+
 }
 
 MainWindow::~MainWindow()


### PR DESCRIPTION
Hi, this is the first time I've done this, so I'm sorry if I did something wrong.

The only modification I made was to make the application icons fit the default theme of the user's system. At least on Linux it works correctly, I haven't tested it on Windows.
In the future, I intend to remove the old icon files, which have become useless.

![Screenshot_20200329_213207](https://user-images.githubusercontent.com/36643465/77865439-c512ca00-7204-11ea-9142-2e2e5e33c011.png)
